### PR TITLE
Adding in dev libraries into classpath

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject lein-eclipse "1.0.0"
+(defproject lein-eclipse "1.1.0"
   :description "A leiningen plugin to create Eclipse project descriptor files."
-  :dev-dependencies [[org.clojure/clojure "1.1.0"]
-                     [org.clojure/clojure-contrib "1.1.0"]
-                     [leiningen "1.1.0"]
-                     [lein-clojars "0.5.0"]])
+  :dev-dependencies [[org.clojure/clojure "1.2.1"]
+                     [org.clojure/clojure-contrib "1.2.0"]
+                     [leiningen "1.3.1"]
+                     [lein-clojars "0.7.0"]])

--- a/src/leiningen/eclipse.clj
+++ b/src/leiningen/eclipse.clj
@@ -23,8 +23,13 @@
   (.isDirectory (File. arg)))
 
 (defn- list-libraries
+  "Find all libraries in the project recursively, including lib and lib/dev"
   [project]
-  (map #(.getPath %) (.listFiles (File. (:library-path project)))))
+  (map 
+    #(.getPath %) 
+    (filter 
+      #(not (.isDirectory %)) 
+      (file-seq (java.io.File. (:library-path project))))))
 
 (defn- create-classpath
   "Print .classpath to *out*."


### PR DESCRIPTION
To support using lein-ring from within Counterclockwise, I've added folder traversal to the list-libraries function. 

My commit message is below:

Increasing clojure version to 1.2.1
Increasing clojure-contrib version to 1.2.0
Increasing leiningen version to 1.3.1
Increasing lein-clojars version to 0.7.0

Modifying list-libraries to support traversing into subfolders, allowing lib/dev to enter the classpath
